### PR TITLE
Simplify drawer content

### DIFF
--- a/shared/my-drawer/MyDrawer-view-model.js
+++ b/shared/my-drawer/MyDrawer-view-model.js
@@ -7,45 +7,8 @@ function MyDrawerViewModel(selectedPage) {
     const viewModel = observableModule.fromObject({
         /* ***********************************************************
          * Use the MyDrawer view model to initialize the properties data values.
-         * The navigationItems property is initialized here and is data bound to <ListView> in the MyDrawer view file.
-         * Add, remove or edit navigationItems to change what is displayed in the app drawer list.
          *************************************************************/
-        navigationItems: [{
-                title: "Home",
-                name: "home",
-                route: "home/home-page",
-                icon: "\uf015",
-                isSelected: selectedPage === "Home"
-            },
-            {
-                title: "Browse",
-                name: "browse",
-                route: "browse/browse-page",
-                icon: "\uf1ea",
-                isSelected: selectedPage === "Browse"
-            },
-            {
-                title: "Search",
-                name: "search",
-                route: "search/search-page",
-                icon: "\uf002",
-                isSelected: selectedPage === "Search"
-            },
-            {
-                title: "Featured",
-                name: "featured",
-                route: "featured/featured-page",
-                icon: "\uf005",
-                isSelected: selectedPage === "Featured"
-            },
-            {
-                title: "Settings",
-                name: "settings",
-                route: "settings/settings-page",
-                icon: "\uf013",
-                isSelected: selectedPage === "Settings"
-            }
-        ]
+        selectedPage: selectedPage
     });
 
     return viewModel;

--- a/shared/my-drawer/MyDrawer.js
+++ b/shared/my-drawer/MyDrawer.js
@@ -13,15 +13,16 @@ function onLoaded(args) {
 }
 
 /* ***********************************************************
- * Use the "itemTap" event handler of the <ListView> component for handling list item taps.
- * The "itemTap" event handler of the app drawer <ListView> is used to navigate the app
+ * Use the "tap" event handler of the <GridLayout> component for handling navigation item taps.
+ * The "tap" event handler of the app drawer <GridLayout> item is used to navigate the app
  * based on the tapped navigationItem's route.
  *************************************************************/
 function onNavigationItemTap(args) {
-    const navigationItem = args.view.bindingContext;
+    const component = args.object;
+    const componentRoute = component.route;
 
     frameModule.topmost().navigate({
-        moduleName: navigationItem.route,
+        moduleName: componentRoute,
         transition: {
             name: "fade"
         }

--- a/shared/my-drawer/MyDrawer.xml
+++ b/shared/my-drawer/MyDrawer.xml
@@ -2,22 +2,47 @@
 The MyDrawer custom component view is where you define what will be displayed in the app drawer.
 Feel free to customize layouts and components to change how your app drawer looks.
 -->
-<StackLayout class="sidedrawer sidedrawer-left" loaded="onLoaded">
+<GridLayout rows="auto, *" class="sidedrawer sidedrawer-left" loaded="onLoaded"
+    xmlns:myDrawer="shared/my-drawer">
     <StackLayout class="sidedrawer-header">
-        <Label class="sidedrawer-header-image fa" text="&#xf2bd;"></Label>
-        <Label class="sidedrawer-header-brand" text="User Name"></Label>
-        <Label class="footnote" text="username@mail.com"></Label>
+        <Label class="sidedrawer-header-image fa" text="&#xf2bd;" />
+        <Label class="sidedrawer-header-brand" text="User Name" />
+        <Label class="footnote" text="username@mail.com" />
     </StackLayout>
 
-    <StackLayout class="sidedrawer-content">
-        <ListView id="listview" separatorColor="transparent" items="{{ navigationItems }}" itemTap="onNavigationItemTap">
-            <ListView.itemTemplate>
-                    <GridLayout columns="auto, *" rows="50"
-                        class="{{ name, 'sidedrawer-list-item sidedrawer-list-item-' + name + (isSelected ? ' selected':'') }}" >
-                        <Label row="0" col="0" text="{{ icon }}" class="fa"/>
-                        <Label row="0" col="1" text="{{ title }}" class="p-r-10"/>
-                    </GridLayout>
-            </ListView.itemTemplate>
-        </ListView>
-    </StackLayout>
-</StackLayout>
+    <ScrollView row="1">
+        <StackLayout class="sidedrawer-content" row="1">
+            <GridLayout columns="auto, *" class="{{ 'sidedrawer-list-item' + (selectedPage === 'Home' ? ' selected': '') }}"
+                route="home/home-page" tap="onNavigationItemTap">
+                <Label row="0" col="0" text="&#xf015;" class="fa" />
+                <Label row="0" col="1" text="Home" class="p-r-10" />
+            </GridLayout>
+
+            <GridLayout columns="auto, *" class="{{ 'sidedrawer-list-item' + (selectedPage === 'Browse' ? ' selected': '') }}"
+                route="browse/browse-page" tap="onNavigationItemTap">
+                <Label row="0" col="0" text="&#xf1ea;" class="fa" />
+                <Label row="0" col="1" text="Browse" class="p-r-10" />
+            </GridLayout>
+
+            <GridLayout columns="auto, *" class="{{ 'sidedrawer-list-item' + (selectedPage === 'Search' ? ' selected': '') }}"
+                route="search/search-page" tap="onNavigationItemTap">
+                <Label row="0" col="0" text="&#xf002;" class="fa" />
+                <Label row="0" col="1" text="Search" class="p-r-10" />
+            </GridLayout>
+
+            <GridLayout columns="auto, *" class="{{ 'sidedrawer-list-item' + (selectedPage === 'Featured' ? ' selected': '') }}"
+                route="featured/featured-page" tap="onNavigationItemTap">
+                <Label row="0" col="0" text="&#xf005;" class="fa" />
+                <Label row="0" col="1" text="Featured" class="p-r-10" />
+            </GridLayout>
+
+            <StackLayout class="hr-light"></StackLayout>
+
+            <GridLayout columns="auto, *" class="{{ 'sidedrawer-list-item' + (selectedPage === 'Settings' ? ' selected': '') }}"
+                route="settings/settings-page" tap="onNavigationItemTap">
+                <Label row="0" col="0" text="&#xf013;" class="fa" />
+                <Label row="0" col="1" text="Settings" class="p-r-10" />
+            </GridLayout>
+        </StackLayout>
+    </ScrollView>
+</GridLayout>

--- a/shared/my-drawer/_MyDrawer.scss
+++ b/shared/my-drawer/_MyDrawer.scss
@@ -35,11 +35,6 @@ $sidedrawer-list-icon-size: 20;
 
     .sidedrawer-content {
         background-color: $side-drawer-background;
-        height: 100%;
-
-        ListView {
-            height: 100%;
-        }
     }
 
     .sidedrawer-list-item {
@@ -61,11 +56,6 @@ $sidedrawer-list-icon-size: 20;
             Label {
                 color: $item-active-color;
             }
-        }
-
-        &.sidedrawer-list-item-settings {
-            border-top-width: 1px;
-            border-top-color: $blue-50;
         }
     }
 }


### PR DESCRIPTION
This is based on Marto's original suggestion https://github.com/NativeScript/template-drawer-navigation-ng/pull/60.

We cannot use the approach in https://github.com/NativeScript/template-drawer-navigation-ng/pull/63 (second level custom components) due to https://github.com/NativeScript/NativeScript/issues/1639 that breaks CSS.