### PR TITLE
update app.gradle

### DIFF
--- a/app/App_Resources/Android/app.gradle
+++ b/app/App_Resources/Android/app.gradle
@@ -8,14 +8,6 @@
 android {  
   defaultConfig {  
     generatedDensities = []
-    applicationId = "__PACKAGE__" 
-    
-    //override supported platforms
-    // ndk {
-    //       abiFilters.clear()
-    //   		abiFilters "armeabi-v7a"
- 		// }
-  
   }  
   aaptOptions {  
     additionalParameters "--no-version-vectors"  


### PR DESCRIPTION
remove __PACKAGENAME__ property as it is no longer needed (from version 4.2.x) and prevents flexibility with changing/separating app ID